### PR TITLE
Add Edge v79 support of prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1190,7 +1190,7 @@
                 "version_added": "76"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "67"


### PR DESCRIPTION
Added support by Edge on version 79 of prefers-color-scheme

A checklist to help your pull request get merged faster:
- Added support of MS Edge v79 of prefers-color-scheme  now that they use Chromium as backend
- Data: https://caniuse.com/#search=prefers-color-scheme
- Test: I made a test using version 79.0.309.68 on Win10 19.09
